### PR TITLE
Add compatibility with Coroner (without any hard deps)

### DIFF
--- a/BepInEx/config/EliteMasterEric-Coroner/Strings_en-us_sirenhead.xml
+++ b/BepInEx/config/EliteMasterEric-Coroner/Strings_en-us_sirenhead.xml
@@ -1,0 +1,13 @@
+<base>
+    <tags>
+        <tag language="en-us" />
+    </tags>
+
+    <strings>
+        <!-- NOTE: If SeriousDeathNotes is turned on, it displays only the first entry, so make the first entry literal! -->
+        <DeathEnemySirenHead text="Eaten by Siren Head." />
+        <DeathEnemySirenHead text="Crushed by Siren Head." />
+        <DeathEnemySirenHead text="NINE. EIGHTEEN. ONE. CHILD. SEVENTEEN. REMOVE. VILE." /> <!-- Reference to Trevor Henderson's caption on the first Siren Head image. -->
+        <DeathEnemySirenHead text="Rushed towards the hurricane siren." />
+    </strings>
+</base>

--- a/CoronerCompatibility.cs
+++ b/CoronerCompatibility.cs
@@ -1,0 +1,42 @@
+using System.Runtime.CompilerServices;
+using GameNetcodeStuff;
+using Coroner;
+
+namespace LethalSirenHead
+{
+    public class CoronerCompatibility
+    {
+        private static bool? _enabled;
+        static string SIREN_HEAD_LANGUAGE_KEY = "DeathEnemySirenHead";
+
+        private static AdvancedCauseOfDeath SIREN_HEAD;
+
+        public static bool enabled
+        {
+            get
+            {
+                if (_enabled == null)
+                {
+                    _enabled = BepInEx.Bootstrap.Chainloader.PluginInfos.ContainsKey("com.elitemastereric.coroner");
+                }
+
+                return (bool)_enabled;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
+        public static void CoronerRegister()
+        {
+            if (Coroner.API.IsRegistered(SIREN_HEAD_LANGUAGE_KEY))
+                return;
+            SIREN_HEAD = Coroner.API.Register(SIREN_HEAD_LANGUAGE_KEY);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
+        public static void CoronerSetCauseOfDeathSirenHead(PlayerControllerB player)
+        {
+            Coroner.API.SetCauseOfDeath(player, SIREN_HEAD);
+        }
+
+    }
+}

--- a/Enemy/SirenHeadAI.cs
+++ b/Enemy/SirenHeadAI.cs
@@ -469,7 +469,14 @@ namespace LethalSirenHead.Enemy
             this.inSpecialAnimation = false;
 
             if (PlayerObject.AllowPlayerDeath())
+            {
                 PlayerObject.KillPlayer(Vector3.zero, false, CauseOfDeath.Crushing, 0);
+                if (CoronerCompatibility.enabled)
+                {
+                    CoronerCompatibility.CoronerRegister();
+                    CoronerCompatibility.CoronerSetCauseOfDeathSirenHead(PlayerObject);
+                }
+            }
             // this number is big because of lobby number mods.
             UpdatePlayerIdOfCaughtPlayerClientRpc(10000);
             makewanderClientRpc();

--- a/LethalSirenHead.csproj
+++ b/LethalSirenHead.csproj
@@ -47,6 +47,9 @@
     <Reference Include="LethalLib">
       <HintPath>..\..\..\AppData\Roaming\Thunderstore Mod Manager\DataFolder\LethalCompany\profiles\Default\BepInEx\plugins\Evaisa-LethalLib\LethalLib\LethalLib.dll</HintPath>
     </Reference>
+      <Reference Include="Coroner">
+          <HintPath>..\..\..\AppData\Roaming\Thunderstore Mod Manager\DataFolder\LethalCompany\profiles\Default\BepInEx\plugins\EliteMasterEric-Coroner/Coroner.dll</HintPath>
+      </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -86,6 +89,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CoronerCompatibility.cs" />
     <Compile Include="Enemy\SirenHeadAI.cs" />
     <Compile Include="Enemy\SirenHeadAnimationCalls.cs" />
     <Compile Include="Enemy\SirenHeadVars.cs" />


### PR DESCRIPTION
Simple extra feature that will change coroner death messages to be siren head specific instead of just 'crushed to death'.

You'll have to include the Coroner dll on your end, but the mod will still work fine even if coroner isn't installed for users. It's just a tiny added extra if they do have it installed.